### PR TITLE
Add z-coordinate args to cluster stats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+### Added
+- The `ComputeClusterStats` class now accepts a keyword argument
+  called `zCoord`. This specifies the name of the column in a
+  DataFrame containing the axial localization coordinates.
+  
+### Changed
+- Functions that are passed to the `statsFunctions` argument of
+  `ComputeClusterStats` objects now take three arguments: group,
+  coordinate, and zCoordinate. They do not necessarily need to use the
+  arguments, but they must accept them.
+
 ## [v1.2.1]
 ### Fixed
 - Fixed a versioning problem related to missing files from the

--- a/bstore/config.py
+++ b/bstore/config.py
@@ -1,4 +1,4 @@
-__bstore_Version__ = '1.2.1'
+__bstore_Version__ = '1.3.0-dev'
 
 """__HDF_AtomID_Prefix__ : str
     String that precedes all attributes marking dataset

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,9 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'B-Store'
-copyright = '2016-2017, Kyle M. Douglass'
+copyright =
+'''2016-2018, The Laboratory of Experimental Biophysics
+EPFL, Switzerland'''
 author = 'Kyle M. Douglass'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -73,9 +75,9 @@ author = 'Kyle M. Douglass'
 # built documents.
 #
 # The short X.Y version.
-version = '1.2.1'
+version = '1.3.0-dev'
 # The full version, including alpha/beta/rc tags.
-release = '1.2.1'
+release = '1.3.0-dev'
 
 # Napoleon settings
 napoleon_include_private_with_doc = False

--- a/docs/other_programs.rst
+++ b/docs/other_programs.rst
@@ -7,8 +7,8 @@ Using B-Store with Other Software
 :Author: Kyle M. Douglass
 :Contact: kyle.m.douglass@gmail.com
 :organization: École Polytechnique Fédérale de Lausanne (EPFL)
-:revision: $Revision: 0 $
-:date: 2016-08-11
+:revision: $Revision: 1 $
+:date: 2018-04-24
 
 :abstract:
 
@@ -55,5 +55,5 @@ writes OME-XML metadata, simply specify the pixel size in the
 ``widefieldPixelSize`` attribute described above.
 
 .. _HDFDatabase: http://b-store.readthedocs.io/en/latest/bstore.html#bstore.database.HDFDatabase
-.. _HDF5 Plugin for ImageJ and Fiji: http://lmb.informatik.uni-freiburg.de/resources/opensource/imagej_plugins/hdf5.html
+.. _HDF5 Plugin for ImageJ and Fiji: https://github.com/fiji/HDF5_Vibez
 

--- a/examples/Computing customized cluster statistics.ipynb
+++ b/examples/Computing customized cluster statistics.ipynb
@@ -274,9 +274,9 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEKCAYAAAD9xUlFAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAGV5JREFUeJzt3X20XXV95/H3J4S0VyFc00acyvReig+xOOk1LfZBRm4o\nGVlYcSprBjM6cmuWbUZHcGpdWHEWZU216hpbrDVFp4FbGY2OpF1C0alkmdvlw9RG4BKLBLB6LtqW\ncKiFos1ImHznj7PPyeVyH87Z53ey9+/cz2uts5K9784+HzbJ/u79++4HRQRmZmYAa6oOYGZm9eGi\nYGZmHS4KZmbW4aJgZmYdLgpmZtbhomBmZh1rqw7QDUm+btbMrISIUC/LZ3OmEBG1/1x99dWVZ3BO\nZ3RO52x/ysimKOSg0WhUHaErzplODhnBOVPLJWcZLgpmZtbhopDQ1NRU1RG64pzp5JARnDO1XHKW\nobLjTieSpMghp5lZnUgihrXRnIOZmZmqI3TFOdPJISM4Z2q55Cyj8qIg6TRJn5J0j6S7Jf1s1ZnM\nzFaryoePJE0DfxERN0haCzwtIv5pwTIePjIz61GZ4aNKi4Kk9cCdEXHWCsu5KJiZ9SjHnsKZwMOS\nbpB0h6SPSBqpOFNpuYwzOmc6OWQE50wtl5xlVF0U1gJbgA9FxBbgn4G3VxvJzGz1qvrZR98Bvh0R\nXy2mbwKuXGzBqakpxsfHARgdHWViYoLJyUngeNX2dHfT7Xl1yZPz9OTkZK3yLDfdVpc83p7pp2dm\nZpiengbo7C97VYdG818Ab4iI+yRdTavRfOWCZdxTMDPrUY49BYDLgY9JmgV+Cnh3xXlKW3gEUVfO\nmU4OGcE5U8slZxlVDx8REXcB51Sdw8zMajB81A0PH5mZ9S7X4SMzM6sJF4WEchlndM50csgIzpla\nLjnLcFEwM7MO9xTMzIaUewpmZtYXF4WEchlndM50csgIzplaLjnLcFEwM7MO9xTMzIaUewpmZtYX\nF4WEchlndM50csgIzplaLjnLcFEwM7MO9xTMzIaUewpmZtYXF4WEchlndM50csgIzplaLjnLcFEw\nM7MO9xTMzIaUewpmZtYXF4WEchlndM50csgIzplaLjnLcFEwM7MO9xTMzIaUewpmZtYXF4WEchln\ndM50csgIzplaLjnLcFEwM7MO9xTMzIaUewpmZtYXF4WEchlndM50csgIzplaLjnLcFEwM7MO9xTM\nzIaUewpmZtYXF4WEchlndM50csgIzplaLjnLcFEwM7MO9xTMzIZUtj0FSWsk3SHp5qqzmJmtZrUo\nCsAVwNerDtGvXMYZnTOdHDKCc6aWS84yKi8Kks4ALgL+qOosZmarXeU9BUmfAt4FnAa8NSIuXmQZ\n9xTMzHqUXU9B0suBwxExC6j4mJlZRdZW/P0vAS6WdBEwApwq6aMR8bqFC05NTTE+Pg7A6OgoExMT\nTE5OAsfH96qebs+rS56lpq+99tpabr8ct+fCrFXnWWp6dnaWt7zlLbXJs9S0t2f/2296ehqgs7/s\nVeXDR22SziPz4aOZmZnO/6g6c850csgIzplaLjnLDB+5KJiZDamsi8JyXBTMzHqXXaN52MwfD60z\n50wnh4zgnKnlkrMMFwUzM+vw8JGZ2ZDy8JGZmfXFRSGhXMYZnTOdHDKCc6aWS84yXBTMzKzDPQUz\nsyHlnoKZmfXFRSGhXMYZnTOdHDKCc6aWS84yXBTMzKzDPQUzsyHlnoKZmfXFRSGhXMYZnTOdHDKC\nc6aWS84yXBTMzKzDPQWzIddsNmk0GoyPj7Nx48aq42Qvp+3pnoKZPcmePZ9kbGwT27btZGxsE3v2\nfLLqSFlbDdvTZwoJ5fKKPudMp84Zm80mY2ObOHJkP/BdYAMjI1uZmztU2yNcb8+0fKZgZh2NRoN1\n68aBzcWczZx88hiNRqO6UBlbLdvTZwpmQ+rJR7abgYO1P7Ktsxy3p88UzKxj48aN7N69i5GRraxf\nv4WRka3s3r2rtjuwulst29NFIaFcrl12znTqnnH79kuZmzvEe9/7q8zNHWL79kurjrQsb8/quSiY\nDbmNGzeyadOmoTuircqwb0/3FMzMhpR7CmZm1hcXhYTqPh7a5pzp5JARnDO1XHKW4aJgZmYd7imY\nmQ0p9xTMzKwvLgoJ5TLO6Jzp5JARnDO1XHKW4aJgZmYd7imYmQ2pMj2FtV2u+CTg9PnLR8QDvcUz\nM7O6W3H4SNKbgcPAbcCtxefPBpwrS7mMMzpnOjlkBOdMLZecZXRzpnAF8PyI+IfUXy7pDOCjtM5C\njgH/IyJ+P/X3mJlZd1bsKUjaD2yLiCeSf7n0LOBZETEr6RTgduCVEXFowXLuKZiZ9WhQPYVvAjOS\nbgV+0J4ZEb/bY76niIgHgQeL339P0j3As4FDy/5BMxs6zWaTRqPB+Pj40D6BNAfdXJL6AK1+wjrg\n1HmfpCSNAxPAV1Kv+0TJZZzROdPJISPUP+eePZ9kbGwTW7e+hrGxTezZ88mqIy2r7tuzHyueKUTE\nNQDF8A4R8b3UIYp13wRcMYj1m1l9NZtNdux4Y/Gay+8CG9ixYysXXHC+zxgqsGJRkPRC4EZgQzH9\nMPC6iLg7RQBJa2kVhBsj4tNLLTc1NcX4+DgAo6OjTExMMDk5CRyv2p7ubro9ry55cp6enJysVZ7l\nptvqkqc9vXfvXtas+RFa7z0GmEHaQKPRYOPGjZXny2l7zszMMD09DdDZX/aqm0bzl4GrImJ/MT0J\nvDsifqHUNz51/R8FHo6IX19mGTeazYZUs9lkbGxTcaawGTjIyMhW5uYO+UyhT4N6IN7T2wUBICJm\ngKf3mG1Rkl4CvAY4X9Kdku6QdGGKdVdh4RFEXTlnOjlkhHrn3LhxI7t372JkZCtPe9pzGRnZyu7d\nu2pdEOq8PfvV1dVHkv4rrSEkgNfSuiKpbxHxJeCkFOsys3xt334pF1xwPnv37uWSSy6pdUEYdt0M\nHz0DuAY4t5j1BeC3IuIfB5xtfgYPH5mZ9ajM8JEfiGdmNqSS9hQkXVv8eoukmxd++g07jHIZZ3TO\ndHLICM6ZWi45y1iup9DuIfz3ExHEzMyq101P4YqI+MBK8wbJw0dmZr0b1CWply0yb6qXLzEzszws\n11PYLukW4MwF/YT2vei2QC7jjM6ZTg4ZwTlTyyVnGcv1FL4M/D3wo8D7581/DDg4yFBmZlYNX5Jq\nZjakkr5PQdIXI+JcSY8B8/fIAiIi1pfMaWZmNbVkTyEizi1+PTUi1s/7nOqCsLhcxhmdM50cMoJz\nppZLzjJWvPpI0lmSfqj4/aSkyyWNDj6amZmdaN3cpzAL/AwwDnwG+DRwdkRcNPB0xzO4p2Bm1qNB\n3adwLCKeAH4Z+GBEvA34F2UCmtmJ12w2OXDgAM1ms+ooQ2HYt2c3ReGopO20bmL7s2LeyYOLlK9c\nxhmdM526Z/S7j9PKbXuW0U1R+BXg54F3RcS3JJ3J8ecimVlNzX/38fe//xGOHNnPjh1vHNoj3EFb\nLduzq/sUJK0DnldM3hsRRwea6qnf756CWY8OHDjAtm07efTR2zvz1q/fwr59H+acc86pMFmectye\nA+kpFO9kvh/4ELALuE/SS0slNLMTZnx8nMcfb3D8AQQHOXp0rvQL3Ve71bI9uxk+ej/wbyLivIh4\nKfAy4PcGGytPdR8PbXPOdOqc0e8+TivH7VlGN+9oPjki7m1PRMR9ktxoNsuA332c1mrYnt3cp3A9\ncAz4n8Ws1wAnRcTrB5xtfgb3FMzMejSQdzQXdzO/CTi3mPUFYFdE/KBUyhJcFMzMejeQRnOx8/8D\n4BrgauBDJ7Ig5KTO46HzOWc6OWQE50wtl5xlrNhTkPRy4Drgb2g9IfVMSb8WEZ8ddDgzMzuxuhk+\nOgT8UkR8o5g+C7g1IjadgHztDJUMHzWbTRqNBuPj48kaSoNYp5nZYgb17KPH2gWh8E1ab18bau3b\n2bdt25nsdvZBrNPMLKVuisJXJX1G0pSky4BbgAOSXiXpVQPOV4n5t7M/+ujtXd/Ovtw4Y9l1DkIu\n46E55MwhIzhnarnkLKObovDDwGHgPGASaAIjwCuAXxpYsgo1Gg3WrRsHNhdzNnPyyWM0Go1ardPM\nLDW/o3kRzWaTsbFNHDmyn9ZO/CAjI1uZmztUug8wiHWamS1nUD2F+V9wR2+R8jT/dvb167ckuZ19\nEOs0M0utp6JA65LUVWH79kuZmzvEvn0fZm7uENu3X7rin1lpnLHMOgchl/HQHHLmkBGcM7VccpbR\nzX0KbwZujIhHgFsHH6k+Nm7cmPxIfhDrNDNLpZv7FH4beDVwB3A98Ocn+qYBP+bCzKx3g3rMxTuB\n5wK7gSngfknvLm5i65ukCyUdknSfpCtTrNPMzMrpqqdQHKY/WHyeAJ4B3CTpff18uaQ1tJ6r9DLg\nbGC7pBN2p3RKzWaT6667LotX8+UyHppDzhwygnOmlkvOMrp589oVkm4H3gd8CfhXEfGfgJ8GLunz\n+18M3B8Rc8UrPj8BvLLPdZ5w7TuVf+M3ftd3KptZ1rrpKVwDXB8Rc4v87AURcU/pL5cuAV4WEb9a\nTL8WeHFEXL5gudr2FHz/gZnVVZmewopXH0XE1cv8rHRB6NXU1FTnXaijo6NMTEwwOTkJHD+Vq2K6\n0WiwZs2PAN8tkm5G2sDevXvZuXNn5fk87WlPr57pmZkZpqenAcq/OzoiKvsAPwf873nTbweuXGS5\nqKuHHnooRkY2BNwVsD/grhgZ2RAPPfRQ1dGWtH///qojdCWHnDlkjHDO1HLJWew7e9ov93rzWmoH\ngOdIGpO0jtalrzdXnKknT36Z9xt8p7KZZa3yZx9JuhD4AK2m9+6IeM8iy0TVOVfi9ySYWd0M5B3N\ndZBDUTAzq5uBPxDPltdu+NSdc6aTQ0ZwztRyyVmGi4KZmXV4+MjMbEh5+CixZrPJgQMHkj66YhDr\nNDNLxUVhCe1HV2zbtrPrR1esNM5YZp2DkMt4aA45c8gIzplaLjnLcFFYRLPZZMeON3LkyH4effR2\njhzZz44db+zr6H4Q6zQzS809hUUcOHCAbdt28uijt3fmrV+/hX37Psw555xTm3WamS3HPYVExsfH\nefzxBnCwmHOQo0fnyj9LZEDrNDNLzUVhEfMfXbF+/ZauH12x3Dhj2XUOQi7joTnkzCEjOGdqueQs\nY8WnpK5W27dfygUXnJ/00RWDWKeZWUruKZiZDSn3FMzMrC8uCgnlMs7onOnkkBGcM7VccpbhomBm\nZh3uKZiZDSn3FMzMrC8uCgnlMs7onOnkkBGcM7VccpbhomBmZh3uKZiZDSn3FMzMrC8uCgnlMs7o\nnOnkkBGcM7VccpbhomBmZh3uKZiZDSn3FMzMrC8uCgnlMs7onOnkkBGcM7VccpbhomBmZh3uKZiZ\nDSn3FMzMrC8uCgnlMs7onOnkkBGcM7VccpbhomBmZh3uKZiZDSn3FMzMrC8uCgnlMs7onOnkkBGc\nM7VccpZRWVGQ9D5J90ialbRX0vqqspiZWUtlPQVJFwCfj4hjkt4DRET85hLLuqdgZtajrHoKEbEv\nIo4Vk38JnFFVFjMza6lLT+H1wGerDtGvXMYZnTOdHDKCc6aWS84y1g5y5ZJuA06fPwsI4KqIuKVY\n5irgaER8fLl1TU1NMT4+DsDo6CgTExNMTk4Cx/8HVT3dVpc8S03Pzs7WKk/u2zOH6dnZ2VrlyX26\nrttzZmaG6elpgM7+sleV3qcgaQp4A3B+RPxgmeXcUzAz61GZnsJAzxSWI+lC4G3AS5crCGZmduJU\n2VP4IHAKcJukOyTtqjBLEguHPerKOdPJISM4Z2q55CyjsjOFiHhuVd9tZmaL87OPzMyGVFb3KZiZ\nWf24KCSUyzijc6aTQ0ZwztRyyVmGi4KZmXW4p2BmNqTcUzAzs764KCSUyzijc6aTQ0ZwztRyyVmG\ni4KZmXW4p2BmNqTcUzAzs764KCSUyzijc6aTQ0ZwztRyyVmGi4KZmXW4p2BmNqTcUzAzs764KCSU\nyzijc6aTQ0ZwztRyyVmGi4KZmXW4p2BmNqTcUzAzs764KCSUyzijc6aTQ0ZwztRyyVmGi4KZmXW4\np2BmNqTcUzAzs764KCSUyzijc6aTQ0ZwztRyyVmGi4KZmXW4p2BmNqTcUzAzs764KCSUyzijc6aT\nQ0ZwztRyyVmGi4KZmXW4p2BmNqTcUzAzs764KCSUyzijc6aTQ0ZwztRyyVmGi4KZmXW4p2BmNqSy\n7ClIequkY5I2VJ3FzGy1q7QoSDoD2AbMVZkjlVzGGZ0znRwygnOmlkvOMqo+U/g94G0VZ0hmdna2\n6ghdcc50csgIzplaLjnLqKwoSLoY+HZEfK2qDKk98sgjVUfoinOmk0NGcM7UcslZxtpBrlzSbcDp\n82cBAbwTeAetoaP5P1vS1NQU4+PjAIyOjjIxMcHk5CRw/FSu6um2uuRZarrRaDAzM1ObPLlvzxym\nG40GbXXIk/t0XbfnzMwM09PTAJ39Zc8i4oR/gBcCDwLfBL4FHAUawDOXWD5ycNlll1UdoSvOmU4O\nGSOcM7Vcchb7zp72z7W4JFXSt4AtEfGPS/y8+pBmZhmKHi9JHejwUQ+CZYaPev2PMjOzcmpxpmBm\nZvVQ9SWpZmZWI9kUBUnvk3SPpFlJeyWtrzpTm6QLJR2SdJ+kK6vOsxhJZ0j6vKS7JX1N0uVVZ1qO\npDWS7pB0c9VZliLpNEmfKv5e3i3pZ6vOtBhJ/0XSX0s6KOljktZVnQlA0m5JhyUdnDfvGZI+J+le\nSX8u6bQqMxaZFstZq/3RYhnn/aynp0ZkUxSAzwFnR8QEcD/wmxXnAVo7L+APgJcBZwPbJW2qNtWi\nngB+PSLOBn4eeFNNc7ZdAXy96hAr+ADwmYh4AfBTwD0V53kKST8GvJnWhRybafURX11tqo4baP27\nme/twL6IeD7weerx73yxnHXbHy2WsdRTI7IpChGxLyKOFZN/CZxRZZ55XgzcHxFzEXEU+ATwyooz\nPUVEPBgRs8Xvv0drB/bsalMtrviLfBHwR1VnWUpxZPivI+IGgIh4IiL+qeJYSzkJeLqktcDTgL+r\nOA8AEfFFYOEVh68E/rj4/R8D//aEhlrEYjnrtj9aYltCiadGZFMUFng98NmqQxSeDXx73vR3qOnO\ntk3SODABfKXaJEtq/0Wu81UQZwIPS7qhGOb6iKSRqkMtFBF/B7wfeAD4W+CRiNhXbaplPTMiDkPr\nQAZ4ZsV5ulGn/VFH2adG1KooSLqtGPdsf75W/PqKectcBRyNiI9XGDVbkk4BbgKuKM4YakXSy4HD\nxVmNWOFO9wqtBbYAH4qILcA/0xr6qBVJo7SOvseAHwNOkfQfqk3VkzofGNR2f1QcoLwDuHr+7G7+\nbF3uUwAgIrYt93NJU7SGFc4/IYG687fAj8+bPqOYVzvF8MFNwI0R8emq8yzhJcDFki4CRoBTJX00\nIl5Xca6FvkPrKOyrxfRNQB0vMrgA+GZEfBdA0p8AvwDUaic2z2FJp0fEYUnPAh6qOtBSaro/ajsL\nGAfukiRa+6XbJb04IpbdprU6U1iOpAtpDSlcHBE/qDrPPAeA50gaK67qeDVQ1ytmrge+HhEfqDrI\nUiLiHRHx4xHxE7S25edrWBAohji+Lel5xaxfpJ6N8QeAn5P0w8XO4RepV0N84dngzcBU8fvLgLoc\nvDwpZ033R52MEfHXEfGsiPiJiDiT1kHMi1YqCJBRUQA+CJwC3FaM4e6qOhBARPw/4D/TuhrhbuAT\nEVGnf3QASHoJ8BrgfEl3FtvwwqpzZe5y4GOSZmldffTuivM8RUT8Fa2zmDuBu2jtND5SaaiCpI8D\nXwaeJ+kBSb8CvAfYJuleWgXsPVVmhCVz1mp/tETG+ZZ9asST1uU7ms3MrC2nMwUzMxswFwUzM+tw\nUTAzsw4XBTMz63BRMDOzDhcFMzPrcFEwS0TSF4tfxyRtnzf/pyVdW10ys+75PgWzxCRNAm+NiFes\ntKxZ3fhMwYaapJ+RdJekdZKeXrxs5icXLHODpD+UdKB4WdLLi/k/JOn64qGMtxc7eyT9pKSvFHey\nzko6q5j/WLHK3wHOLX5+haTzJN1SLPMMSX9aZPqypBcW868uXpSyX9I3JL35BG0isyep1QPxzFKL\niK9K+jTwLloP2LsxIhZ7RtFYRJwj6TnA/mJH/ybgWERslvR84HOSngvsBK6NiD3FQwZPan9d8evb\naZ0pXAwg6bx5P7sGuCMiflnSVuBG4EXFz54PTAKnAfdK2lU8RsXshHFRsNXgv9F6cOERWm8hW8z/\nAoiIb0j6G+AFwLnA7xfz75XUAJ4H/B/gquJlQH8aEd/oIcu5wKuKde6XtKF4nDnArRHxBPAPkg4D\np1OTF+LY6uHhI1sNfpTWw8tOBUYk/Xb7oYDzlpnfXBNwjKdqP4FyD/AK4P8Cn2kPKyUw/2mbx/BB\nm1XARcFWg+uAdwIfA94bEe+MiBcVL8dp+3dqOYvWW9XuBb5A68myFI/I/pe0hnXOjIhvRcQHaT3a\neXOxjvZTKB+jVYAW8wXgtcU6J4GH6/iyI1u9fCRiQ03SfwQej4hPSFoDfEnSZETMLFj0AeCvaO3M\nfy0iHi8eh/yHkg4CR4HLIuKopH9frPco8Pe0+hVw/GzjIHBM0p3ANDA773t+C7he0l3A94Gl3hXh\nywKtEr4k1VY9STcAt0TEn1SdxaxqHj4y81G5WYfPFMzMrMNnCmZm1uGiYGZmHS4KZmbW4aJgZmYd\nLgpmZtbhomBmZh3/HwajOryUHeVWAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEKCAYAAAASByJ7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAF95JREFUeJzt3X+U5XV93/Hn24WWcYewsZhRBtol\nimsIi2xnmmrW1hliAokUNqSeqmiItmdrjwKxQMIeatS21m2RHE2N4VAxmCrO4ZBltaBZ0N0JjUbj\nrmsYEFYIijIgP5pCGd0gC+/+cb/Dzi6zM3dm7v1+7nfn+ThnDvfHd+/n9d273Nd8f9zPNzITSZJe\nUDqAJKk3WAiSJMBCkCRVLARJEmAhSJIqFoIkCbAQJEkVC0GSBFgIkqTKEaUDLMSxxx6bq1evrm28\nH/3oR6xcubK28Tqt6fmh+evQ9PzgOvSCpebftWvXY5n54vmWa1QhrF69mp07d9Y23vj4OCMjI7WN\n12lNzw/NX4em5wfXoRcsNX9E3N/Ocu4ykiQBFoIkqWIhSJIAC0GSVLEQJEmAhSBJqlgIkiTAQpAk\nVSwESRJgIUiSKhaCJAmwECRJlaKT20XE94AngWeAfZk5XDKPJC1nvTDb6WhmPlY6hCQtd+4ykiQB\n5QshgVsiYldEbCycRZKWtcjMcoNHHJeZD0bEzwC3Ahdk5m0HLbMR2AgwMDAwNDY2Vlu+qakp+vv7\naxuv05qeH5q/Dk3PD65DL1hq/tHR0V1tHaPNzJ74Ad4PXDLXMkNDQ1mnHTt21DpepzU9f2bz16Hp\n+TNdh16w1PzAzmzjc7jYLqOIWBkRR0/fBn4FuKNUHkla7kqeZTQA3BgR0zmuy8w/K5hHkpa1YoWQ\nmfcBryo1viTpQKXPMpIk9QgLQZIEWAiSpIqFIEkCLARJUsVCkCQBFoIkqWIhSJIAC0GSVLEQJEmA\nhSBJqlgIkiTAQpAkVSwESRJgIUiSKhaCJAnogUKIiBURsTsibiqdRZKWs+KFAFwE3FU6hCQtd0UL\nISKOB94AfKJkDkkSRGaWGzziBuBDwNHAJZl51izLbAQ2AgwMDAyNjY3Vlm9qaor+/v7axuu0pueH\n5q9D0/OD69ALlpp/dHR0V2YOz7tgZhb5Ac4CPl7dHgFumu/PDA0NZZ127NhR63id1vT8mc1fh6bn\nz3QdesFS8wM7s43P5ZK7jNYDZ0fE94Ax4PSI+HTBPJK0rBUrhMzclJnHZ+Zq4E3A9sx8a6k8krTc\n9cJZRpKkHnBE6QAAmTkOjBeOIUnLmlsIkiTAQpAkVSwESRJgIUiSKhaCJAmwECRJFQtBkgRYCJKk\nioUgSQIsBElSxUKQJAEWgiSpYiFIkgALQZJUsRAkSUDBQoiIoyLiryLiryPizoj4QKkskqSyWwhP\nAadn5quA04AzI+LVBfNImmHr7knWb97OxOQTrN+8na27J0tHWnbqfg+KXTEtMxOYqu4eWf1kqTyS\n9tu6e5JNWybY+/QzcAJMPr6XTVsmANiwbrBwuuWhxHtQ9BhCRKyIiG8BjwC3ZubXS+aR1HLFtj2t\nD6IZ9j79DFds21Mo0fJT4j2I1i/qZUXEKuBG4ILMvOOg5zYCGwEGBgaGxsbGass1NTVFf39/beN1\nWtPzQ/PXoan5JyafeO72QB88vHf/c2sHjymQaGma+D508j0YHR3dlZnD8y3XE4UAEBHvA36UmR8+\n1DLDw8O5c+fO2jKNj48zMjJS23id1vT80Px1aGr+9Zu3M/l46xPo4rX7uHKitXd5cFUfX7ns9JLR\nFqWJ70Mn34OIaKsQSp5l9OJqy4CI6ANeD9xdKo+k/S49Yw19R6444LG+I1dw6RlrCiVafkq8B8UO\nKgMvBT4VEStoFdP1mXlTwTySKtMHLVv7q59kcFUfl56xxgPKNSrxHpQ8y+h2YF2p8SXNbcO6QTas\nG2R8fJwLzhspHWdZqvs98JvKkiTAQpAkVSwESRJgIUiSKhaCJAmwECRJFQtBkgRYCJKkioUgSQIs\nBElSxUKQJAEWgiSpYiFIkgALQZJUsRAkSUCb10OoLmIzMHP5zPz+UgaOiBOAPwFeAjwLXJ2ZH13K\na0qSFm/eLYSIuAB4GLgVuLn66cSVzfYBF2fmzwGvBt4VESd34HUlCYCtuydZv3k7E5NPsH7zdrbu\nniwdqae1s4VwEbAmM/9PJwfOzIeAh6rbT0bEXcAg8O1OjiNpedq6e5JNWybY+/QzcAJMPr6XTVsm\nALwU6CG0cwzhB8AT3QwREatpXU7z690cR9LyccW2Pa0ymGHv089U1yjWbCIz514g4hpgDa1dRU9N\nP56Zv9+RABH9wJ8DH8zMLbM8vxHYCDAwMDA0NjbWiWHbMjU1RX9/f23jdVrT80Pz16Hp+aG56zAx\nuf/32IE+eHjv/ufWDh5TINHiLfU9GB0d3ZWZw/Mt104hvG+2xzPzA4vMNvO1j6R1PGJbOwUzPDyc\nO3fuXOqwbRsfH2dkZKS28Tqt6fmh+evQ9PzQ3HVYv3k7k4+3WuDitfu4cqK1h3xwVR9fuez0ktEW\nbKnvQUS0VQjzHkOY/uCPiKNbd3Nq0almiIgArgHu6tTWhiRNu/SMNfuPIVT6jlzBpWesKZiqt7Vz\nltEpEbEbuAO4MyJ2RcTPd2Ds9cDbgNMj4lvVz6914HUliQ3rBvnQuWsZXNUHtLYMPnTuWg8oz6Gd\ns4yuBv59Zu4AiIgR4H8Av7iUgTPzL4BYymtI0lw2rBtkw7pBxsfHueC8kdJxel47ZxmtnC4DgMwc\nB1Z2LZEkqYh2thDui4j3Av+zuv9W4LvdiyRJKqGdLYR3AC8GtgA3Vrff3s1QkqT6tXOW0f8FLqwh\niySpoEMWQkR8JDN/OyL+F/C8Lytk5tldTSZJqtVcWwjTxww+XEcQSVJZhyyEzNxV3Tzt4GmpI+Ii\nWtNNSJIOE+0cVD5/lsd+q8M5JEmFzXUM4c3AW4ATI+LzM546GujoVNiSpPLmOobwVVrXKzgWuHLG\n408Ct3czlCSpfnMdQ7gfuB94TX1xJEmlzLXL6C8y87UR8SQHnnYatGY9/amup5Mk1WauLYTXVv89\nur44kqRS2pn++mUR8fer2yMRcWFErOp+NElSndo57fRPgWci4uW0LmhzInBdV1NJkmrXTiE8m5n7\ngF8HPpKZ7wFe2onBI+KTEfFIRNzRideTJC1eO4XwdPWdhPNpXf8Y4MgOjX8tcGaHXktSB23dPcn6\nzduZmHyC9Zu3s3X3ZOlIy07d70E7hfB2WqeefjAzvxsRJwKf7sTgmXkb8LedeC1JnbN19ySbtkw8\nd5H6ycf3smnLhKVQoxLvwbyFkJnfBi4BJiLiFOCBzNzctUSSirti254DLk4PsPfpZ7hi255CiZaf\nEu9BZD5vZusDF2hdQ/lTwPdofQfhBOD86rf7pQeIWA3clJmnHOL5jcBGgIGBgaGxsbFODNuWqakp\n+vv7axuv05qeH5q/Dk3NPzH5xHO3B/rg4b37n1s7eEyBREvTxPehk+/B6Ojorswcnm+5dgphF/CW\nzNxT3X8F8NnMHFpQokO//mrmKISZhoeHc+fOnZ0Yti3j4+OMjIzUNl6nNT0/NH8dmpp//ebtz+2q\nuHjtPq6caH1laXBVH1+57PSS0Ralie9DJ9+DiGirENo5hnDkdBkAZOZ36NxBZUk96NIz1tB35IoD\nHus7cgWXnrGmUKLlp8R7MO8lNIGdEXEN+y+Ycx6wa47l2xYRnwVGgGMj4gHgfZl5TSdeW9LibVg3\nCFDtr36SwVV9XHrGmuceV/eVeA/aKYR/B7yL1nWVA7gN+HgnBs/MN3fidSR13oZ1g2xYN8j4+DgX\nnDdSOs6yVPd7MG8hZOZTEfEx4MvAs8CezPxJ15NJkmo1byFExBuAq4C/obWFcGJE/NvM/GK3w0mS\n6tPOLqMrgdHMvBdak90BNwMWgiQdRto5y+iR6TKo3Ac80qU8kqRC2tlCuDMivgBcT+tCOW8EvhER\n5wJk5pYu5luyrbsnuWLbHh58fC/HdekofR1jSFK3tVMIRwEPA6+r7j8KvAj4F7QKomcLYXoukOmv\nf0/PBQJ07AO7jjEkqQ7tnGX09jqCdMNcc4F06sO6jjEkqQ7tHEN4TkR8s1tBuuHBx/cu6PFeHUOS\n6rCgQqB12mljHLeqb0GP9+oYklSHdq6p/O4Z11C+uct5OqqOuUCc80XS4aKdg8ovoTWf0TeBT0ZE\n5HxTpPaImXOBdOsMoDrGkKQ6tHNQ+T9ExHuBX6F19bSPRcT1wDWZ+TfdDrhU03OBNH0MSeq2to4h\nVFsEP6x+9gE/DdwQEf+ti9kkSTVqZy6jC4HzgceATwCXZubTEfEC4B7gd7obUZJUh3aOIRwLnJuZ\n9898MDOfjYizuhNLklS3do4h/N4cz93V2TiSpFIW+j2EjoqIMyNiT0TcGxGXlcwy09bdk6zfvJ2J\nySdYv3k7W3dPlo4kSV1XrBAiYgXwh8CvAicDb46Ik0vlmTY9N9H0xa2n5yayFCQd7kpuIfwCcG9m\n3lddgW0MOKdgHmDuuYkk6XAWpb5jFhH/EjgzM/9Ndf9twD/NzHcftNxGYCPAwMDA0NjYWFdzTUw+\n8dztgT54eMaURGsHj+nq2J02NTVFf39/6RhL0vR1aHp+cB16wVLzj46O7srM4fmWa+cso26ZbV6k\n57VTZl4NXA0wPDycIyMjXQ11+ebtz+0uunjtPq6caP0VDa7qa9yFxsfHx+n231e3NX0dmp4fXIde\nUFf+kruMHgBOmHH/eODBQlme49xEkparklsI3wBOiogTgUngTcBbCuYBDpybCJ5k0LmJJC0TxQoh\nM/dFxLuBbcAK4JOZeWepPDNNz000Pj7euN1EkrRYJbcQyMwvAF8omUGS1FL0i2mSpN5hIUiSAAtB\nklSxECRJQOGDynXYunuy65e3rGMMSeq2w7oQpieqm56baHqiOqBjH9h1jCFJdTisdxnVMVGdk+FJ\nOlwc1oXw4ON7F/R4r44hSXU4rAvhuFV9C3q8V8eQpDoc1oVQx0R1ToYn6XBxWB9UnjlRXbfOAKpj\nDEmqw2FdCLB/orqmjyFJ3XZY7zKSJLXPQpAkARaCJKlSpBAi4o0RcWdEPBsR8174WZLUfaW2EO4A\nzgVuKzS+JOkgRc4yysy7ACKixPCSpFl4DEGSBEBkZndeOOJLwEtmeeryzPxctcw4cElm7pzjdTYC\nGwEGBgaGxsbGupB2dlNTU/T399c2Xqc1PT80fx2anh9ch16w1Pyjo6O7MnP+47WZWewHGAeG211+\naGgo67Rjx45ax+u0pufPbP46ND1/puvQC5aaH9iZbXzGustIkgSUO+301yPiAeA1wM0Rsa1EDknS\nfqXOMroRuLHE2JKk2bnLSJIEWAiSpIqFIEkCLARJUsVCkCQBFoIkqWIhSJIAC0GSVLEQJEmAhSBJ\nqlgIkiTAQpAkVSwESRJgIUiSKhaCJAkod4GcKyLi7oi4PSJujIhVJXJIkvYrtYVwK3BKZp4KfAfY\nVCiHJKlSpBAy85bM3Ffd/RpwfIkckqT9euEYwjuAL5YOIUnLXWRmd1444kvAS2Z56vLM/Fy1zOXA\nMHBuHiJIRGwENgIMDAwMjY2NdSXvbKampujv769tvE5ren5o/jo0PT+4Dr1gqflHR0d3ZebwvAtm\nZpEf4HzgL4EXtvtnhoaGsk47duyodbxOa3r+zOavQ9PzZ7oOvWCp+YGd2cZn7BGLrpwliIgzgd8F\nXpeZPy6RQZJ0oFLHED4GHA3cGhHfioirCuWQJFWKbCFk5stLjCtJOrReOMtIktQDLARJEmAhSJIq\nFoIkCbAQJEkVC0GSBFgIkqSKhSBJAiwESVLFQpAkARaCJKliIUiSAAtBklSxECRJgIUgSapYCJIk\noFAhRMR/iojbq6ul3RIRx5XIIUnar9QWwhWZeWpmngbcBPxeoRySpEqRQsjM/zfj7kogS+SQJO0X\nmWU+iyPig8BvAk8Ao5n56CGW2whsBBgYGBgaGxurLePU1BT9/f21jddpTc8PzV+HpucH16EXLDX/\n6OjorswcnnfBzOzKD/Al4I5Zfs45aLlNwAfaec2hoaGs044dO2odr9Oanj+z+evQ9PyZrkMvWGp+\nYGe28Rl7xKIrZ/6ieX2bi14H3Ay8r1tZJEnzK3WW0Ukz7p4N3F0ihyRpv65tIcxjc0SsAZ4F7gfe\nWSiHJKlSpBAy8zdKjCtJOrRiZxktRkQ8SmuLoi7HAo/VOF6nNT0/NH8dmp4fXIdesNT8/ygzXzzf\nQo0qhLpFxM5s51StHtX0/ND8dWh6fnAdekFd+Z3LSJIEWAiSpIqFMLerSwdYoqbnh+avQ9Pzg+vQ\nC2rJ7zEESRLgFoIkqWIhzCIizoyIPRFxb0RcVjrPQkXECRGxIyLuiog7I+Ki0pkWIyJWRMTuiLip\ndJbFiIhVEXFDRNxdvRevKZ1poSLiPdW/oTsi4rMRcVTpTHOJiE9GxCMRcceMx14UEbdGxD3Vf3+6\nZMb5HGIdrqj+Hd0eETdGxKpujG0hHCQiVgB/CPwqcDLw5og4uWyqBdsHXJyZPwe8GnhXA9cB4CLg\nrtIhluCjwJ9l5iuBV9GwdYmIQeBCYDgzTwFWAG8qm2pe1wJnHvTYZcCXM/Mk4MvV/V52Lc9fh1uB\nUzLzVOA7tCYF7TgL4fl+Abg3M+/LzJ8AY8A5hTMtSGY+lJnfrG4/SeuDaLBsqoWJiOOBNwCfKJ1l\nMSLip4B/DlwDkJk/yczHy6ZalCOAvog4Angh8GDhPHPKzNuAvz3o4XOAT1W3PwVsqDXUAs22Dpl5\nS2buq+5+DTi+G2NbCM83CPxgxv0HaNiH6UwRsRpYB3y9bJIF+wjwO7Tmu2qinwUeBf642u31iYhY\nWTrUQmTmJPBh4PvAQ8ATmXlL2VSLMpCZD0HrlyXgZwrnWap3AF/sxgtbCM8XszzWyFOxIqIf+FPg\nt/PAq9T1tIg4C3gkM3eVzrIERwD/GPijzFwH/Ije31VxgGpf+znAicBxwMqIeGvZVMtbRFxOa5fw\nZ7rx+hbC8z0AnDDj/vH0+GbybCLiSFpl8JnM3FI6zwKtB86OiO/R2mV3ekR8umykBXsAeCAzp7fM\nbqBVEE3yeuC7mfloZj4NbAF+sXCmxXg4Il4KUP33kcJ5FiUizgfOAs7LLn1fwEJ4vm8AJ0XEiRHx\n92gdRPt84UwLEhFBa9/1XZn5+6XzLFRmbsrM4zNzNa2//+2Z2ajfTDPzh8APqmneAX4J+HbBSIvx\nfeDVEfHC6t/UL9GwA+OVzwPnV7fPBz5XMMuiRMSZwO8CZ2fmj7s1joVwkOrAzbuBbbT+8V+fmXeW\nTbVg64G30frN+lvVz6+VDrUMXQB8JiJuB04D/kvhPAtSbd3cAHwTmKD1edHT3/iNiM8CfwmsiYgH\nIuJfA5uBX46Ie4Bfru73rEOsw8eAo4Fbq/+fr+rK2H5TWZIEbiFIkioWgiQJsBAkSRULQZIEWAiS\npIqFIHVYRHy1+u/qiHjLjMeHI+IPyiWT5uZpp1KXRMQIcElmnlU6i9QOtxC0LETEP6nmkj8qIlZW\nc/yfctAy10bEVRHxvyPiO9WcSlR/5o8jYqKaqG60evznI+Kvqi8K3R4RJ1WPT1UvuRn4Z9Xz74mI\nkelrO1Rz9G+t/tzXIuLU6vH3V/Phj0fEfRFxYV1/R9IRpQNIdcjMb0TE54H/DPQBn87MO2ZZdDXw\nOuBlwI6IeDnwruo11kbEK4FbIuIVwDuBj2bmZ6ppTlYc9FqXMWMLodpimPYBYHdmboiI04E/ofVt\nZoBXAqO0vpm6JyL+qJpLSOoqC0HLyX+kNVfV39G68Mtsrs/MZ4F7IuI+Wh/OrwX+O0Bm3h0R9wOv\noDW9wOXVtRu2ZOY9C8jyWuA3qtfcHhH/ICKOqZ67OTOfAp6KiEeAAVqT5Uld5S4jLScvAvpp/eZ9\nVER8cHqupxnLHHxQLZl9SnQy8zrgbGAvsK36Tb9dc02z/tSMx57BX9xUEwtBy8nVwHtpzSX/XzPz\n8sw8LTNPm7HMGyPiBRHxMloXudkD3AacB1DtKvqHtHbl/CxwX2b+Aa0ZNU89aLwnaZXPbGa+5gjw\nWJOuWaHDk795aFmIiN8E9mXmddV1s78aEadn5vaDFt0D/Dmt3TTvzMy/i4iPA1dFxASti5P8VmY+\nFRH/CnhrRDwN/JDWLqmZbgf2RcRf07pO7u4Zz72f1tXUbgd+zP7pmaViPO1UqkTEtcBNmXlD6SxS\nCe4ykiQBbiFIkipuIUiSAAtBklSxECRJgIUgSapYCJIkwEKQJFX+P8J531ejBWE/AAAAAElFTkSu\nQmCC\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x7f3683cc7400>"
+       "<Figure size 432x288 with 1 Axes>"
       ]
      },
      "metadata": {},
@@ -331,9 +331,9 @@
        "      <th>x [nm]_center</th>\n",
        "      <th>y [nm]_center</th>\n",
        "      <th>number_of_localizations</th>\n",
+       "      <th>convex_hull</th>\n",
        "      <th>eccentricity</th>\n",
        "      <th>radius_of_gyration</th>\n",
-       "      <th>convex_hull</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -344,8 +344,8 @@
        "      <td>0.0</td>\n",
        "      <td>5</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.632456</td>\n",
        "      <td>1.0</td>\n",
+       "      <td>0.632456</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -353,9 +353,9 @@
        "      <td>10.0</td>\n",
        "      <td>2.0</td>\n",
        "      <td>5</td>\n",
+       "      <td>8.0</td>\n",
        "      <td>4.0</td>\n",
        "      <td>2.000000</td>\n",
-       "      <td>8.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -366,9 +366,9 @@
        "0           0            0.0            0.0                        5   \n",
        "1           1           10.0            2.0                        5   \n",
        "\n",
-       "   eccentricity  radius_of_gyration  convex_hull  \n",
-       "0           1.0            0.632456          1.0  \n",
-       "1           4.0            2.000000          8.0  "
+       "   convex_hull  eccentricity  radius_of_gyration  \n",
+       "0          1.0           1.0            0.632456  \n",
+       "1          8.0           4.0            2.000000  "
       ]
      },
      "execution_count": 6,
@@ -408,10 +408,12 @@
    },
    "outputs": [],
    "source": [
-    "def VarTimesTwo(group, coordinates):\n",
+    "def VarTimesTwo(group, coordinates, zCoordinate):\n",
     "        # Multiples each localization position by 2, then computes\n",
     "        # the sum of the variances. This is a bit silly but serves\n",
-    "        # as a good example.\n",
+    "        # as a good example. We also don't use the z-coordinate in\n",
+    "        # this example, but we must still provide it as an argument\n",
+    "        # because other stats functions might use it.\n",
     "        variances = group[coordinates].apply(lambda x: x * 2).var(ddof=0)\n",
     "        return variances.sum()"
    ]
@@ -431,7 +433,7 @@
    },
    "outputs": [],
    "source": [
-    "def VarTimesThree(group, coordinates):\n",
+    "def VarTimesThree(group, coordinates, zCoordinate):\n",
     "        # Multiples each localization position by 3, then computes\n",
     "        # the sum of the variances.\n",
     "        variances = group[coordinates].apply(lambda x: x * 3).var(ddof=0)\n",
@@ -468,11 +470,11 @@
        "      <th>x [nm]_center</th>\n",
        "      <th>y [nm]_center</th>\n",
        "      <th>number_of_localizations</th>\n",
-       "      <th>var times two</th>\n",
-       "      <th>eccentricity</th>\n",
        "      <th>three var</th>\n",
-       "      <th>radius_of_gyration</th>\n",
        "      <th>convex_hull</th>\n",
+       "      <th>eccentricity</th>\n",
+       "      <th>radius_of_gyration</th>\n",
+       "      <th>var times two</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -482,11 +484,11 @@
        "      <td>0.0</td>\n",
        "      <td>0.0</td>\n",
        "      <td>5</td>\n",
-       "      <td>1.6</td>\n",
-       "      <td>1.0</td>\n",
        "      <td>3.6</td>\n",
-       "      <td>0.632456</td>\n",
        "      <td>1.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.632456</td>\n",
+       "      <td>1.6</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -494,11 +496,11 @@
        "      <td>10.0</td>\n",
        "      <td>2.0</td>\n",
        "      <td>5</td>\n",
-       "      <td>16.0</td>\n",
-       "      <td>4.0</td>\n",
        "      <td>36.0</td>\n",
-       "      <td>2.000000</td>\n",
        "      <td>8.0</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>2.000000</td>\n",
+       "      <td>16.0</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -509,9 +511,9 @@
        "0           0            0.0            0.0                        5   \n",
        "1           1           10.0            2.0                        5   \n",
        "\n",
-       "   var times two  eccentricity  three var  radius_of_gyration  convex_hull  \n",
-       "0            1.6           1.0        3.6            0.632456          1.0  \n",
-       "1           16.0           4.0       36.0            2.000000          8.0  "
+       "   three var  convex_hull  eccentricity  radius_of_gyration  var times two  \n",
+       "0        3.6          1.0           1.0            0.632456            1.6  \n",
+       "1       36.0          8.0           4.0            2.000000           16.0  "
       ]
      },
      "execution_count": 9,
@@ -546,6 +548,103 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Computing statistics over z-coordinates\n",
+    "\n",
+    "As mentioned above, the statsFunctions must also accept a z-coordinate argument. Here's how we would use it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>cluster_id</th>\n",
+       "      <th>x [nm]_center</th>\n",
+       "      <th>y [nm]_center</th>\n",
+       "      <th>number_of_localizations</th>\n",
+       "      <th>convex_hull</th>\n",
+       "      <th>mean_z</th>\n",
+       "      <th>eccentricity</th>\n",
+       "      <th>radius_of_gyration</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>5</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>-4.575011</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>0.632456</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>5</td>\n",
+       "      <td>8.0</td>\n",
+       "      <td>22.822626</td>\n",
+       "      <td>4.0</td>\n",
+       "      <td>2.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   cluster_id  x [nm]_center  y [nm]_center  number_of_localizations  \\\n",
+       "0           0            0.0            0.0                        5   \n",
+       "1           1           10.0            2.0                        5   \n",
+       "\n",
+       "   convex_hull     mean_z  eccentricity  radius_of_gyration  \n",
+       "0          1.0  -4.575011           1.0            0.632456  \n",
+       "1          8.0  22.822626           4.0            2.000000  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Add some z-date to the DataFrame.\n",
+    "df['z [nm]'] = 50 * np.random.randn(len(df))\n",
+    "\n",
+    "# Define a function that computes the mean of the z-coordinate.\n",
+    "# We won't use the xy coordinates.\n",
+    "def meanZ(group, coordinates, zCoord):\n",
+    "    return group[zCoord].mean()\n",
+    "\n",
+    "# Setup the customStats dictionary.\n",
+    "customStats = {'mean_z' : meanZ}\n",
+    "\n",
+    "# Create the new processor. We need to specify the name of the z-coordinate column now.\n",
+    "zStatsProc = proc.ComputeClusterStats(coordCols = ['x [nm]', 'y [nm]'],\n",
+    "                                      zCoord = 'z [nm]',\n",
+    "                                      statsFunctions = customStats)\n",
+    "\n",
+    "# Compute the statistics\n",
+    "zStatsProc(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Summary\n",
     "+ `ComputeClusterStats` combines localizations with the same cluster ID's and computes a single number from the localizations' coordinates\n",
     "+ Custom statistics may be computed by adding a dictionary of functions to `ComputeClusterStats`'s constructor\n",
@@ -555,8 +654,9 @@
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -570,7 +670,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.5"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,13 @@ except ImportError:
     from distutils.core import setup
 
 config = {
-    'description'     : 'Lightweight data management and analysis tools for single-molecule microscopy.',
+    'description'     : 'Lightweight data management and analysis '
+                        'tools for single-molecule microscopy.',
     'author'          : 'Kyle M. Douglass',
     'url'             : 'https://github.com/kmdouglass/bstore',
     'download_url'    : 'https://github.com/kmdouglass/bstore',
     'author_email'    : 'kyle.m.douglass@gmail.com',
-    'version'         : '1.2.1',
+    'version'         : '1.3.0-dev',
     'packages'        : find_packages(),
     'scripts'         : ['bin/bstore'],
     'name'            : 'bstore'

--- a/utils/anaconda_build.sh
+++ b/utils/anaconda_build.sh
@@ -2,12 +2,12 @@
 conda build utils/anaconda --channel soft-matter
 
 # Update path to .tar.bz2 file
-conda convert --platform all ~/anaconda3/conda-bld/linux-64/bstore-1.2.1-py35heacb6a4_0.tar.bz2 -o ~/src/bstore-build
+conda convert --platform all ~/anaconda3/conda-bld/linux-64/bstore-1.3.0-py35heacb6a4_0.tar.bz2 -o ~/src/bstore-build
 
 # Upload to anaconda
 # anaconda login
-anaconda upload ../bstore-build/linux-64/bstore-1.2.1-py35heacb6a4_0.tar.bz2
-anaconda upload ../bstore-build/linux-32/bstore-1.2.1-py35heacb6a4_0.tar.bz2
-anaconda upload ../bstore-build/win-64/bstore-1.2.1-py35heacb6a4_0.tar.bz2
-anaconda upload ../bstore-build/win-32/bstore-1.2.1-py35heacb6a4_0.tar.bz2
-anaconda upload ../bstore-build/osx-64/bstore-1.2.1-py35heacb6a4_0.tar.bz2
+anaconda upload ../bstore-build/linux-64/bstore-1.3.0-py35heacb6a4_0.tar.bz2
+anaconda upload ../bstore-build/linux-32/bstore-1.3.0-py35heacb6a4_0.tar.bz2
+anaconda upload ../bstore-build/win-64/bstore-1.3.0-py35heacb6a4_0.tar.bz2
+anaconda upload ../bstore-build/win-32/bstore-1.3.0-py35heacb6a4_0.tar.bz2
+anaconda upload ../bstore-build/osx-64/bstore-1.3.0-py35heacb6a4_0.tar.bz2


### PR DESCRIPTION
### Added
- The `ComputeClusterStats` class now accepts a keyword argument called `zCoord`. This specifies the name of the column in a DataFrame containing the axial localization coordinates.
  
### Changed
- Functions that are passed to the `statsFunctions` argument of `ComputeClusterStats` objects now take three arguments: group, coordinate, and zCoordinate. They do not necessarily need to use the arguments, but they must accept them.
