### PR TITLE
Fixed event loop bug.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project will be documented in this file.
   coordinate, and zCoordinate. They do not necessarily need to use the
   arguments, but they must accept them.
 
+### Fixed
+- The event loop associated with interactive windows from
+  OverlayClusters was not terminating as it should have been when the
+  window was closed. This was caused by a deprecation of the
+  `start_event_loop_default()` method in matplotlib 2.1 and is now
+  fixed by using the more recent `start_event_loop()` method.
+
 ## [v1.2.1]
 ### Fixed
 - Fixed a versioning problem related to missing files from the

--- a/bstore/multiprocessors.py
+++ b/bstore/multiprocessors.py
@@ -522,7 +522,7 @@ class OverlayClusters:
             self._fig.canvas.mpl_connect('close_event', onClose)
             plt.connect('key_press_event',
                         lambda event: keyMonitor(event, self))
-            self._fig.canvas.start_event_loop_default()
+            self._fig.canvas.start_event_loop()
 
         if centerNameTemp:
             # Reset the center names to the value that was overridden


### PR DESCRIPTION
### Fixed
- The event loop associated with interactive windows from OverlayClusters was not terminating as it should have been when the window was closed. This was caused by a deprecation of the `start_event_loop_default()` method in matplotlib 2.1 and is now fixed by using the more recent `start_event_loop()` method.