### PR TITLE
Fix issue84

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose numpy scipy matplotlib scikit-learn pytables h5py pandas=0.19.2
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose numpy scipy matplotlib scikit-learn pytables h5py pandas
   - source activate test-environment
   - conda install -c soft-matter trackpy
   - conda install -c kmdouglass tifffile=0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ All notable changes to this project will be documented in this file.
 - An error would occur with Pandas > 0.20 inside the
   `HDFDatastore._sortDatasets()` method when there were mixed types of
   acqID's. This is now fixed by implicitly converting acqID's to
-  strings before sorting them.
+  strings before sorting them. 
 
 ## [v1.2.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ All notable changes to this project will be documented in this file.
   fixed by using the more recent `start_event_loop()` method.
 - Fixed a bug in conf.py related to module mocking which prevented
   automated documentation builds.
+- An error would occur with Pandas > 0.20 inside the
+  `HDFDatastore._sortDatasets()` method when there were mixed types of
+  acqID's. This is now fixed by implicitly converting acqID's to
+  strings before sorting them.
 
 ## [v1.2.1]
 ### Fixed

--- a/bstore/database.py
+++ b/bstore/database.py
@@ -861,7 +861,12 @@ class HDFDatastore(Datastore):
         if dsInfo:
             # Build the DataFrame with indexes prefix and acqID. These are
             # the primary identifiers for a dataset and are always required;
-            df = pd.DataFrame(dsInfo).set_index(['prefix', 'acqID'])
+            df = pd.DataFrame(dsInfo)
+
+            # Prevents an error comparing acqID's of different types.
+            df['acqID'] = df['acqID'].astype(str)
+
+            df.set_index(['prefix', 'acqID'])
             df.sort_index(inplace=True)
 
             return df

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 nose
 scikit-learn
-pandas=0.19.2
+pandas
 trackpy
 numpy
 scipy

--- a/utils/anaconda/meta.yaml
+++ b/utils/anaconda/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - scikit-learn
     - pytables
     - h5py
-    - pandas 0.19.2
+    - pandas
     - trackpy 0.3.2
     - tifffile 0.10.0
     - nb_conda


### PR DESCRIPTION
### Fixed
- An error would occur with Pandas > 0.20 inside the `HDFDatastore._sortDatasets()` method when there were mixed types of acqID's. This is now fixed by implicitly converting acqID's to strings before sorting them. 